### PR TITLE
Add per-repo user-specific diff statistics to graph output

### DIFF
--- a/graphs.py
+++ b/graphs.py
@@ -81,7 +81,7 @@ def generate_figure(graphs: List[Graph], path: str):
             heights.append((0.3 * max(graph.count)))
 
     figure, axis = plot.subplots(len(filtered),
-                                 figsize=(12, sum(heights) + 1),
+                                 figsize=(12, sum(heights) + 2.5),
                                  dpi=600,
                                  gridspec_kw={'height_ratios': [h / heights[0] for h in heights]})
 
@@ -127,9 +127,14 @@ def generate_chart(data: list, minimum: int, graph_type: str, legend: str, count
             axis.set_title(f'{title} (total: {classes[i]})')
 
         elif graph_type == 'bar':
+            if len(data) == 1:
+                colors = ['C0']
+            else:
+                colors = ['C2', 'C3']
+
             y = [i for i in range(counts[i])]
 
-            bars = axis.barh(y, values[i], align='center')
+            bars = axis.barh(y, values[i], align='center', color=colors[i])
             axis.set_yticks(y)
             axis.set_yticklabels(keys[i])
             axis.invert_yaxis()

--- a/graphs.py
+++ b/graphs.py
@@ -1,0 +1,141 @@
+import matplotlib.pyplot as plot
+from typing import List
+
+class Graph:
+    def __init__(self,
+                 data: list = [],
+                 minimum: int = 0,
+                 min_count: int = 0,
+                 kind: str = 'pie',
+                 legend: str = 'Default graph legend',
+                 title: str = 'Default graph title',
+                 counter: str = 'total'):
+
+        self.minimum = minimum
+        self.min_count = min_count
+        self.kind = kind
+        self.legend = legend
+        self.title = title
+        self.counter = counter
+
+        # Graph generation code expects a list but callers might specify a single list if they only need one dataset.
+        if isinstance(data, dict):
+            self.data = [data]
+        else:
+            self.data = data
+
+        # Normalize and count the elements
+        self.normalize_data()
+
+        self.count = []
+        for dataset in self.data:
+            self.count.append(len(dataset))
+
+    def normalize_data(self):
+        result = []
+
+        for i,dataset in enumerate(self.data):
+            ds = dict(self.data[i])
+
+            # Remove summatory keys from the dictionary.
+            # The additional 'nope' is there just to avoid having to put everything in a try in case the "total" key does not exist. 
+            ds.pop('total', 'nope')
+            ds.pop('past_year', 'nope')
+
+            other = 0
+
+            for key in list(ds.keys()):
+                if ds[key] < self.minimum:
+                    other += ds.pop(key)
+
+            # Order data dictionary by size of elements
+            ds = {k:v for k,v in sorted(ds.items(), key=lambda x: int(x[1]), reverse=True)}
+
+            if other > 0:
+                ds['other'] = other
+
+            result.append(ds)
+
+        self.data = result
+
+    def is_suitable(self) -> bool:
+        for c in self.count:
+            if c > 0:
+                return True
+        
+        return False
+
+
+def generate_figure(graphs: List[Graph], path: str):
+    filtered = sorted([graph for graph in graphs if graph.is_suitable()], key=lambda x: 0 if x.kind == 'pie' else 1)
+    heights = []
+
+    # If we have no suitable graphs, return without doing nothing
+    if len(filtered) == 0:
+        return
+
+    for graph in filtered:
+        if graph.kind == 'pie':
+            heights.append(7)
+        else:
+            heights.append((0.3 * max(graph.count)))
+
+    figure, axis = plot.subplots(len(filtered),
+                                 figsize=(12, sum(heights) + 1),
+                                 dpi=600,
+                                 gridspec_kw={'height_ratios': [h / heights[0] for h in heights]})
+
+    # We need a list for the following for loop and if len(filtered) = 1 axis is just an object. Maybe there is a better way to do this?
+    if len(filtered) == 1:
+        axis = [axis]
+
+    for i,graph in enumerate(filtered):
+        generate_chart(graph.data, graph.minimum, graph.kind, graph.legend, graph.counter, graph.title, axis[i])
+    
+    plot.tight_layout()
+    plot.savefig(path, bbox_inches='tight')
+    plot.close(figure)
+
+
+def generate_chart(data: list, minimum: int, graph_type: str, legend: str, counter: str, title: str, axis):
+    keys    = [dataset.keys() for dataset in data]
+    values  = [dataset.values() for dataset in data]
+    counts  = [len(v) for v in values]
+    totals  = [sum(dataset[key] for key in dataset) for dataset in data]
+    classes = [len(dataset) if counter == 'classes' else totals[i] for i,dataset in enumerate(data)]
+    labels  = [(f'{key} ({((dataset[key] * 100)/totals[i]):.2f}%)' for key in dataset) for i,dataset in enumerate(data)]
+
+    for i,dataset in enumerate(data):
+        if len(dataset) == 0:
+            continue
+
+        if graph_type == 'pie':
+            # Set the color map and generate a properly sized color cycle
+            colors = []
+            colormaps = {'Pastel1':9, 'Accent':8, 'Set1':9, 'tab20':20, 'tab20b':20}
+
+            for colormap in colormaps:
+                cmap = plot.get_cmap(colormap)
+                colors += [cmap(i/colormaps[colormap]) for i in range(colormaps[colormap])]
+
+            step = int(len(colors)/counts[i])
+            axis.set_prop_cycle('color', [colors[i*step] for i in range(counts[i])])
+
+            wedges, texts = axis.pie(values[i], counterclock=False, startangle=90)
+            legend = axis.legend(wedges, labels[i], title=legend, bbox_to_anchor=(1.01, 1), loc='upper left')
+            axis.set_aspect('equal')
+            axis.set_title(f'{title} (total: {classes[i]})')
+
+        elif graph_type == 'bar':
+            y = [i for i in range(counts[i])]
+
+            bars = axis.barh(y, values[i], align='center')
+            axis.set_yticks(y)
+            axis.set_yticklabels(keys[i])
+            axis.invert_yaxis()
+            axis.set_xlabel(legend)
+            axis.set_title(f'{title} (total: {classes[i]})')
+
+            for bar in bars:
+                width = bar.get_width()
+                axis.annotate(str(width), xy=(width, bar.get_y() + bar.get_height() / 2), xytext=(3,0), textcoords='offset points', ha='left', va='center')

--- a/main.py
+++ b/main.py
@@ -5,9 +5,10 @@ import re
 import os
 import json
 import matplotlib.pyplot as plot
-from typing import List
 from datetime import datetime, timedelta
 from subprocess import run
+
+from graphs import Graph,generate_figure
 
 from ignored_files import ignored_files
 from config import owner, is_organization, output_file, output_dir, token, \
@@ -15,31 +16,6 @@ from config import owner, is_organization, output_file, output_dir, token, \
 
 url_clone = "https://github.com"
 url_api = "https://api.github.com"
-
-
-class Graph:
-    def __init__(self,
-                 data: dict = {},
-                 minimum: int = 0,
-                 min_count: int = 0,
-                 kind: str = 'pie',
-                 legend: str = 'Default graph legend',
-                 title: str = 'Default graph title',
-                 counter: str = 'total'):
-
-        self.minimum = minimum
-        self.min_count = min_count
-        self.kind = kind
-        self.legend = legend
-        self.title = title
-        self.counter = counter
-        
-        self.data = _normalize_data(data, minimum)
-        self.count = len(self.data)
-
-    def is_suitable(self) -> bool:
-        return self.count >= self.min_count
-
 
 def raise_rate_limited_exception():
     raise Exception("You are getting rate-limited by GitHub's servers. Try again in a few minutes.") from None
@@ -179,9 +155,9 @@ def get_contributors_commits_stats(repos: list, header: dict) -> tuple:
                           for author in json_response},
         }
 
+        additions_stats[repo] = {}
+        deletions_stats[repo] = {}
         for user in json_response:
-            additions_stats[repo] = {}
-            deletions_stats[repo] = {}
 
             additions_stats[repo][user['author']['login']] = sum(week['a'] for week in user['weeks'])
             deletions_stats[repo][user['author']['login']] = sum(week['d'] for week in user['weeks'])
@@ -359,112 +335,6 @@ def get_lines_stats(repos: list, use_cloc: bool) -> tuple:
     return stats, lang_by_repo, lang_total
 
 
-def __generate_chart(data: dict, minimum: int, graph_type: str, legend: str, counter: str, title: str, axis):
-    keys = data.keys()
-    values = data.values()
-    count = len(values)
-
-    total = 0
-    labels = []
-
-    for key in data:
-        total += data[key]
-    
-    for key in data:
-        percentage = (float(data[key] * 100) / float(total))
-        labels.append(f'{key} ({percentage:.2f}%)')
-
-    if counter == 'classes':
-        total_count = len(data)
-    else:
-        total_count = total
-
-    if graph_type == 'pie':
-        # Set the color map and generate a properly sized color cycle
-        colors = []
-        colormaps = {'Pastel1':9, 'Accent':8, 'Set1':9, 'tab20':20, 'tab20b':20}
-
-        for cm in colormaps:
-            cmap = plot.get_cmap(cm)
-            colors += [cmap(i/colormaps[cm]) for i in range(colormaps[cm])]
-
-        step = int(len(colors)/count)
-        axis.set_prop_cycle('color', [colors[i*step] for i in range(count)])
-
-        wedges, texts = axis.pie(values, counterclock=False, startangle=90)
-        legend = axis.legend(wedges, labels, title=legend, bbox_to_anchor=(1.01, 1), loc='upper left')
-        axis.set_aspect('equal')
-        axis.set_title(f'{title} (total: {total_count})')
-
-    elif graph_type == 'bar':
-        y = [i for i in range(count)]
-
-        bars = axis.barh(y, values, align='center')
-        axis.set_yticks(y)
-        axis.set_yticklabels(keys)
-        axis.invert_yaxis()
-        axis.set_xlabel(legend)
-        axis.set_title(f'{title} (total: {total_count})')
-
-        for bar in bars:
-            width = bar.get_width()
-            axis.annotate(str(width), xy=(width, bar.get_y() + bar.get_height() / 2), xytext=(3,0), textcoords='offset points', ha='left', va='center')
-
-
-def _normalize_data(data: dict, min_value: float):
-    result = dict(data)
-
-    # Remove summatory keys from the dictionary.
-    # The additional 'nope' is there just to avoid having to put everything in a try in case the "total" key does not exist. 
-    result.pop('total', 'nope')
-    result.pop('past_year', 'nope')
-
-    other = 0
-
-    for key in list(result.keys()):
-        if result[key] < min_value:
-            other += result.pop(key)
-
-    # Order data dictionary by size of elements
-    result = {k:v for k,v in sorted(result.items(), key=lambda x: int(x[1]), reverse=True)}
-
-    if other > 0:
-        result['other'] = other
-    
-    return result
-
-
-def generate_figure(graphs: List[Graph], path: str):
-    filtered = sorted([graph for graph in graphs if graph.is_suitable()], key=lambda x: 0 if x.kind == 'pie' else 1)
-    heights = []
-
-    # If we have no suitable graphs, return without doing nothing
-    if len(filtered) == 0:
-        return
-
-    for graph in filtered:
-        if graph.kind == 'pie':
-            heights.append(7)
-        else:
-            heights.append((0.3 * graph.count))
-
-    figure, axis = plot.subplots(len(filtered),
-                                 figsize=(12, sum(heights) + 1),
-                                 dpi=600,
-                                 gridspec_kw={'height_ratios': [h / heights[0] for h in heights]})
-
-    # We need a list for the following for loop and if len(filtered) = 1 axis is just an object. Maybe there is a better way to do this?
-    if len(filtered) == 1:
-        axis = [axis]
-
-    for i,graph in enumerate(filtered):
-        __generate_chart(graph.data, graph.minimum, graph.kind, graph.legend, graph.counter, graph.title, axis[i])
-    
-    plot.tight_layout()
-    plot.savefig(path, bbox_inches='tight')
-    plot.close(figure)
-
-
 def get_language_stats(repos: list, header: dict):
     langs_by_repo = {}
     langs_total = {}
@@ -537,6 +407,8 @@ def print_all_stats(repos: list, commits_stats: dict, lines_stats: dict, contrib
         sloc_by_repo = {}
         lang_by_repo = {}
 
+        diff_by_repo = {}
+
         if commits_stats is not None:
             yearly_commits_by_repo = Graph(commits_stats, 10, 1, 'pie', 'Repositories', 'Commits in the last year by repository')
             global_graphs['yearly_commits_by_repo.svg'] = yearly_commits_by_repo
@@ -553,7 +425,11 @@ def print_all_stats(repos: list, commits_stats: dict, lines_stats: dict, contrib
                     repo_commits[repo] = Graph(contributors_stats[repo]['past_year'], 1, 2, 'bar', 'Commits', f'Commits to {owner}/{repo} in the last year by contributor')
 
         if additions_stats is not None and deletions_stats is not None:
-            pass #TODO: Stuff
+            for repo in repos:
+                additions = additions_stats[repo]
+                deletions = deletions_stats[repo]
+
+                diff_by_repo[repo] = Graph([additions, deletions], 1, 1, kind='bar')
 
         if language_total is not None:
             total = language_total['total']
@@ -580,7 +456,7 @@ def print_all_stats(repos: list, commits_stats: dict, lines_stats: dict, contrib
 
         print("\n\nGenerating repo-specific graphs...")
         for i, graph in enumerate(repos):
-            graphlist = [g[graph] for g in [repo_commits, yearly_repo_commits, sloc_by_repo, lang_by_repo] if len(g) > 0]
+            graphlist = [g[graph] for g in [repo_commits, yearly_repo_commits, sloc_by_repo, lang_by_repo, diff_by_repo] if len(g) > 0]
             generate_figure(graphlist, os.path.join(graph_dir, f'{graph}.svg'))
 
             print(f"\t{i + 1}/{len(repos)} - {graph}.svg")


### PR DESCRIPTION
A new graph is generated in each one of the per-repo figure with a bar graph containing the all-time and yearly diff statistics for each contributor for that specific repo.

The new graph is a stacked bar graph with two colors, the familiar green and red for added and removed lines.